### PR TITLE
Pass encoding to readFileSync as a string to maintain backwards compatibility

### DIFF
--- a/lib/html2jade.coffee
+++ b/lib/html2jade.coffee
@@ -12,7 +12,7 @@ class Parser
       cb('null file')
     else
       # workaround jsdom file path mishandling issue in 0.6.3+
-      arg = FS.readFileSync(arg, encoding: "utf8") if @options.inputType is "file"
+      arg = FS.readFileSync(arg, "utf8") if @options.inputType is "file"
       @jsdom.env arg, cb
 
 class Writer

--- a/lib/html2jade.js
+++ b/lib/html2jade.js
@@ -21,9 +21,7 @@
         return cb('null file');
       } else {
         if (this.options.inputType === "file") {
-          arg = FS.readFileSync(arg, {
-            encoding: "utf8"
-          });
+          arg = FS.readFileSync(arg, "utf8");
         }
         return this.jsdom.env(arg, cb);
       }


### PR DESCRIPTION
html2jade was failing with node v0.8 and earlier due to the encoding being passed to readFileSync as an options object. This commit reverts to passing the encoding as a string to maintain backwards compatibility ([this is still supported in v0.10](https://github.com/joyent/node/wiki/Api-changes-between-v0.8-and-v0.10)).

Prior to this fix, running html2jade with node v0.8 would log a misleading "unknown encoding" error for any html file. I believe that is what was occurring in issue https://github.com/donpark/html2jade/issues/53.
