### PR TITLE
Windows support (complete!)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,7 @@ try {
 function parsePath(arg) {
   if (typeof arg !== 'string') {
     console.error('invalid input: ' + arg);
-  } else if (arg[0] === '/') {
+  } else if (path.resolve('/',arg) === arg) {
     // already absolute path
     return arg;
   } else if (arg.length >= 2 && arg.substring(0, 2) === '~/') {
@@ -90,7 +90,7 @@ for (var i = 0; i < args.length; i++) {
     continue;
   }
 
-  if (typeof arg === 'string') {
+  if (typeof arg === 'string' && !existsSync(arg)) {
     try { inputUrl = url.parse(arg); } catch (err) {}
   }
   if (inputUrl && inputUrl.protocol) {

--- a/lib/html2jade.coffee
+++ b/lib/html2jade.coffee
@@ -12,7 +12,7 @@ entOptions = numeric: false
 
 class Parser
   constructor: (@options = {}) ->
-    @jsdom = require('jsdom')
+    @jsdom = require('jsdom-little')
 
   parse: (arg, cb) ->
     if not arg

--- a/lib/html2jade.js
+++ b/lib/html2jade.js
@@ -25,7 +25,7 @@
   Parser = (function() {
     function Parser(options) {
       this.options = options != null ? options : {};
-      this.jsdom = require('jsdom');
+      this.jsdom = require('jsdom-little');
     }
 
     Parser.prototype.parse = function(arg, cb) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "commander": "*",
     "ent": "*",
-    "jsdom": "~0.6"
+    "jsdom-little": "^0.10.5"
   },
   "devDependencies": {
     "async": "*",

--- a/test/testcmd.coffee
+++ b/test/testcmd.coffee
@@ -9,7 +9,7 @@ exec = child_process.exec
 existsSync = fs.existsSync or path.existsSync
 
 html2jade = (inputFile, outputDir, cb) ->
-  cmd = "../cli.js #{inputFile} -o #{outputDir}"
+  cmd = "node ../cli.js #{inputFile} -o #{outputDir}"
   options =
     cwd: __dirname
   # console.log cmd


### PR DESCRIPTION
This is a fix for the Windows command line _and_ jsdom issues.  Specifically:
- In the test script, using "node ./cli.js" instead of expecting cli.js to be executable on its own
- In the CLI, don't make *nix assumptions about paths (i.e., use path.resolve to test absolute path-ness, and don't assume that paths like "e:/foo" are URLs
- in the library, depend on jsdom-little (which doesn't use contextify) instead of jsdom, as html2jade doesn't actually use the parts of jsdom that need contextify.

With these changes "npm test" passes on Windows, at least for me.  Enjoy!
