### PR TITLE
made html2jade to use normal HTML syntax for conditional comments

### DIFF
--- a/lib/html2jade.js
+++ b/lib/html2jade.js
@@ -450,7 +450,7 @@
     Converter.prototype.comment = function(node, output) {
       var condition, data, lines,
         _this = this;
-      condition = node.data.match(/\s*\[(if\s+[^\]]+)\]/);
+      condition = node.data.match(/\s*\[(if\s+[^\]]+)\]|<!\[endif\]/);
       if (!condition) {
         data = node.data || '';
         if (data.length === 0 || data.search(/\r|\n/) === -1) {
@@ -474,18 +474,12 @@
     };
 
     Converter.prototype.conditional = function(node, condition, output) {
-      var conditionalElem, innerHTML;
-      innerHTML = node.textContent.trim().replace(/\s*\[if\s+[^\]]+\]>\s*/, '').replace('<![endif]', '');
-      if (innerHTML.indexOf("<!") === 0) {
-        condition = " [" + condition + "] <!";
-        innerHTML = null;
+      var data;
+      data = node.data || '';
+      if (data.trim().indexOf('<![endif]') === 0) {
+        output.writeln('| ');
       }
-      conditionalElem = node.ownerDocument.createElement('conditional');
-      conditionalElem.setAttribute('condition', condition);
-      if (innerHTML) {
-        conditionalElem.innerHTML = innerHTML;
-      }
-      return node.parentNode.insertBefore(conditionalElem, node.nextSibling);
+      return output.writeln("<!--" + (data.trim()) + "-->");
     };
 
     Converter.prototype.script = function(node, output, tagHead, tagAttr) {


### PR DESCRIPTION
Since Jade does not have any special syntax for conditional comments, normal HTML style conditional comments should be used instead. 
http://jade-lang.com/reference/comments